### PR TITLE
chore: Standardise Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+
+registries:
+
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    labels:
+      - "dependencies"
+      - "standard_change"
+    schedule:
+      interval: daily
+      time: "06:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,5 @@
 version: 2
 
-registries:
-
 updates:
   - package-ecosystem: npm
     directory: "/"


### PR DESCRIPTION
https://www.notion.so/Standardise-Dependabot-Configuration-3367256fbc3280a09197ceb887e6997e

## Summary

- Add dependabot.yml aligned with oaknorthbank org standard template
- Ecosystems: npm
- Schedule: daily at 09:00 Europe/London
- Stack: javascript

## Context

Part of an org-wide initiative to standardise GitHub project configuration
across all oaknorthbank repositories.
