### PR TITLE
chore: add Dependabot cooldown — JavaScript/TypeScript (npm)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,6 @@ updates:
       interval: daily
       time: "06:00"
       timezone: Europe/London
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 5


### PR DESCRIPTION
https://www.notion.so/ADR-011-Introduce-Cooldown-Period-for-Dependency-Updates-2e37256fbc328194b407d081692279d5
https://www.notion.so/Safe-deployment-guardrails-for-SDLC-controls-rollout-3507256fbc3280368c22fc45fe65b8dd

Adds a **3-day cooldown** to Dependabot dependency updates for **JavaScript/TypeScript (npm)**, as required by ADR-011.

The cooldown delays Dependabot PR creation by 3 days after a new package version is published. This provides a buffer to detect supply chain attacks or compromised releases before the organisation automatically adopts them.

**Changes made:**
- `JavaScript/TypeScript (npm)`: added `cooldown: default-days: 3`

**No other changes.** All existing configuration — ignore rules, groups, registry settings, schedules, and PR limits — is untouched.

**Risk classification:** `LOW` — no workflows directory
